### PR TITLE
Add support for servername blacklisting

### DIFF
--- a/ping.php
+++ b/ping.php
@@ -7,8 +7,14 @@
     define('PORT_CHECK_TIMEOUT', 3);
     ini_set('display_errors', DEBUG);
     error_reporting(DEBUG ? E_ALL : 0);
-
+    
     header('Content-type: text/plain');
+    
+    // Define strings to blacklist in server names
+    $blacklist_servernames = "/official/";
+    
+    // Servers (IP) excluded from blacklisting
+    $whitelist_servers = array("162.248.240.74", "144.76.186.56");
 
     // === functions ===
 
@@ -16,7 +22,11 @@
     {
         return @fsockopen($ip, $port, $errno, $errstr, PORT_CHECK_TIMEOUT);
     }
-
+	
+    function check_servername($servername)
+    {
+    	return preg_match($blacklist_servernames, $servername);
+    }
     function updatedbinfo($gameinfo) {
         global $db;
 
@@ -72,7 +82,12 @@
 
         $name = urldecode($_REQUEST['name']);
         $started = '';
-
+        
+        // Check if server is using blacklisted names
+		if (check_servername($name))
+			if (!in_array($ip, $whitelist_servers))
+				die('[002] game server "'.$addr.'" contains blacklisted name');
+				
         $version_arr = explode('@', $_REQUEST['mods']);
         $game_mod = array_shift($version_arr);
         $version = implode('@', $version_arr);

--- a/ping.php
+++ b/ping.php
@@ -14,7 +14,7 @@
     $blacklist_servernames = "/official/";
     
     // Servers (IP) excluded from blacklisting
-    $whitelist_servers = array("162.248.240.74", "144.76.186.56");
+    $whitelist_servers = array("104.238.136.90", "144.76.186.56");
 
     // === functions ===
 

--- a/ping.php
+++ b/ping.php
@@ -7,7 +7,6 @@
     define('PORT_CHECK_TIMEOUT', 3);
     ini_set('display_errors', DEBUG);
     error_reporting(DEBUG ? E_ALL : 0);
-    
     header('Content-type: text/plain');
     
     // Define strings to blacklist in server names

--- a/ping.php
+++ b/ping.php
@@ -83,9 +83,9 @@
         $started = '';
         
         // Check if server is using blacklisted names
-		if (check_servername($name))
-			if (!in_array($ip, $whitelist_servers))
-				die('[002] game server "'.$addr.'" contains blacklisted name');
+	if (check_servername($name))
+		if (!in_array($ip, $whitelist_servers))
+			die('[002] game server "'.$addr.'" contains blacklisted name');
 				
         $version_arr = explode('@', $_REQUEST['mods']);
         $game_mod = array_shift($version_arr);


### PR DESCRIPTION
Adds support for blacklisting servernames, also adds a whitelist option
for IP's who shouldn't be affected by the blacklist.

That way we can change the "EU/US baxxster" into actual Official servers, but this would require us to filter out the non-official servers claiming to be so

I'm as usual rusty with GitHub, but I think I did everything right from the fork to the PR :p