### PR TITLE
Fix unknown/hidden locations being displayed as "false"

### DIFF
--- a/games.php
+++ b/games.php
@@ -45,6 +45,9 @@ function query_games($protocol)
                 array_pop($country);
                 $country = implode(":", $country);
                 $country = geoip_country_name_by_name($country);
+
+                if (!$country)
+                    $country = "Unknown";
             }
 
             $ttl = $row['ts'] + STALE_GAME_TIMEOUT - time();


### PR DESCRIPTION
Replaces the Location "false" with "Unknown". This makes it feel much less like a bug:
![grafik](https://user-images.githubusercontent.com/21260178/138315127-012f5343-2885-4747-a383-d9063c4693f8.png)

Untested, since I do currently not have the capabilities to do that.