### PR TITLE
Add a rewrite rule for appimagecheck.zsync

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,3 +8,4 @@ RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^([^.]+)?$ $1.php [L]
+RewriteRule ^appimagecheck\.zsync$ appimagecheck.php [L]


### PR DESCRIPTION
The desktop integration from appimaged expects the path portion of the zsync URL to end in ".zsync"

See https://github.com/OpenRA/OpenRA/issues/20232