### PR TITLE
Match at least one character in rewrite rule

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,5 +7,5 @@ Redirectmatch ^/$ http://www.openra.net/games/
 RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^([^.]+)?$ $1.php [L]
+RewriteRule ^([^.]+)+$ $1.php [L]
 RewriteRule ^appimagecheck\.zsync$ appimagecheck.php [L]


### PR DESCRIPTION
The idea of this rewrite rule is to add a `.php` to any requested path. Adding it to an empty string doesn't make sense so we want to match at least one character.